### PR TITLE
FIX - Printing function names

### DIFF
--- a/ADT_AVL/ADT_AVL.c
+++ b/ADT_AVL/ADT_AVL.c
@@ -12,7 +12,7 @@ AVLNode* AVL_initialize(void)
   return NULL;
 }
 
-AVLNode* AVL_insertion(AVLNode* tree, char *info, int* flag, int value)
+AVLNode* AVL_insert(AVLNode* tree, char *info, int* flag, int value)
 {
   comp_insert_AVL++;
   if(tree)
@@ -20,7 +20,7 @@ AVLNode* AVL_insertion(AVLNode* tree, char *info, int* flag, int value)
     comp_insert_AVL++;
     if(strcmp(info, tree->info) > 0)
     {
-      tree->right = AVL_insertion(tree->right, info, flag, value);   // Inserts node
+      tree->right = AVL_insert(tree->right, info, flag, value);   // Inserts node
 
       comp_insert_AVL++;
       if(*flag) // If flag != 0
@@ -49,7 +49,7 @@ AVLNode* AVL_insertion(AVLNode* tree, char *info, int* flag, int value)
     }
     else
     {
-      tree->left = AVL_insertion(tree->left, info, flag, value);   // Inserts node
+      tree->left = AVL_insert(tree->left, info, flag, value);   // Inserts node
 
       comp_insert_AVL++;
       if(*flag) // If flag != 0
@@ -174,7 +174,7 @@ AVLNode* AVL_remove(AVLNode* tree, char *info)
   return answer;
 }
 
-AVLNode* AVL_consult(AVLNode* tree, char *info)
+AVLNode* AVL_search(AVLNode* tree, char *info)
 {
   AVLNode* answer = NULL;  // Initializing return.
 
@@ -187,10 +187,10 @@ AVLNode* AVL_consult(AVLNode* tree, char *info)
     else
     {
       comp_search_AVL++;
-      if(strcmp(info,tree->info) > 0)   // If info is greater than info's tree, the answer will be the result of right consult.
-        answer = AVL_consult(tree->right, info);
-      else                    // Else, it must be the result of left consult.
-        answer = AVL_consult(tree->left, info);
+      if(strcmp(info,tree->info) > 0)   // If info is greater than info's tree, the answer will be the result of right search.
+        answer = AVL_search(tree->right, info);
+      else                    // Else, it must be the result of left search.
+        answer = AVL_search(tree->left, info);
     }
   }
 
@@ -235,15 +235,15 @@ int AVL_print(AVLNode* tree, char* operation)
   {
     if(strcmp(operation, "PREFIXED") == 1)
     {
-      answer = AVL_prefixed(tree, operation[8]);
+      answer = AVL_pre_order(tree, operation[8]);
     }
     else if(strcmp(operation, "POSTFIXED") == 1)
     {
-      answer = AVL_postfixed(tree, operation[9]);
+      answer = AVL_post_order(tree, operation[9]);
     }
     else if(strcmp(operation, "CENTER") == 1)
     {
-      answer = AVL_centerside(tree, operation[6]);
+      answer = AVL_in_order(tree, operation[6]);
     }
     else
       answer--;
@@ -254,21 +254,21 @@ int AVL_print(AVLNode* tree, char* operation)
   return answer;
 }
 
-int AVL_prefixed(AVLNode* tree, char side)
+int AVL_pre_order(AVLNode* tree, char side)
 {
   int answer = 1;
 
   if(side == 'L')
-    AVL_prefixedL(tree, 1);
+    AVL_pre_orderL(tree, 1);
   else if(side == 'R')
-    AVL_prefixedR(tree, 1);
+    AVL_pre_orderR(tree, 1);
   else
     answer--;   // Answer = 0;
 
   return answer;
 }
 
-void AVL_prefixedL(AVLNode* tree, int aux)
+void AVL_pre_orderL(AVLNode* tree, int aux)
 {
   int i; // Counter
 
@@ -281,20 +281,20 @@ void AVL_prefixedL(AVLNode* tree, int aux)
 
       puts(tree->info);
 
-      AVL_prefixedL(tree->left, aux+1);
-      AVL_prefixedL(tree->right, aux+1);
+      AVL_pre_orderL(tree->left, aux+1);
+      AVL_pre_orderL(tree->right, aux+1);
     }
   }
   else
   {
     puts(tree->info);
 
-    AVL_prefixedL(tree->left, aux);
-    AVL_prefixedL(tree->right, aux);
+    AVL_pre_orderL(tree->left, aux);
+    AVL_pre_orderL(tree->right, aux);
   }
 }
 
-void AVL_prefixedR(AVLNode* tree, int aux)
+void AVL_pre_orderR(AVLNode* tree, int aux)
 {
   int i; // Counter
 
@@ -307,34 +307,34 @@ void AVL_prefixedR(AVLNode* tree, int aux)
 
       puts(tree->info);
 
-      AVL_prefixedR(tree->right, aux+1);
-      AVL_prefixedR(tree->left, aux+1);
+      AVL_pre_orderR(tree->right, aux+1);
+      AVL_pre_orderR(tree->left, aux+1);
     }
   }
   else
   {
     puts(tree->info);
 
-    AVL_prefixedR(tree->right, aux);
-    AVL_prefixedR(tree->left, aux);
+    AVL_pre_orderR(tree->right, aux);
+    AVL_pre_orderR(tree->left, aux);
   }
 }
 
-int AVL_postfixed(AVLNode* tree, char side)
+int AVL_post_order(AVLNode* tree, char side)
 {
   int answer = 1;
 
   if(side == 'L')
-    AVL_postfixedL(tree, 1);
+    AVL_post_orderL(tree, 1);
   else if(side == 'R')
-    AVL_postfixedR(tree, 1);
+    AVL_post_orderR(tree, 1);
   else
     answer--;   // Answer = 0;
 
   return answer;
 }
 
-void AVL_postfixedL(AVLNode* tree, int aux)
+void AVL_post_orderL(AVLNode* tree, int aux)
 {
   int i; // Counter
 
@@ -342,8 +342,8 @@ void AVL_postfixedL(AVLNode* tree, int aux)
   {
     if(tree)
     {
-      AVL_postfixedL(tree->left, aux+1);
-      AVL_postfixedL(tree->right, aux+1);
+      AVL_post_orderL(tree->left, aux+1);
+      AVL_post_orderL(tree->right, aux+1);
 
       for(i = 0; i < aux; i++)  // Printing the "stairs".
         printf("=");
@@ -353,14 +353,14 @@ void AVL_postfixedL(AVLNode* tree, int aux)
   }
   else
   {
-    AVL_postfixedL(tree->left, aux);
-    AVL_postfixedL(tree->right, aux);
+    AVL_post_orderL(tree->left, aux);
+    AVL_post_orderL(tree->right, aux);
 
     puts(tree->info);
   }
 }
 
-void AVL_postfixedR(AVLNode* tree, int aux)
+void AVL_post_orderR(AVLNode* tree, int aux)
 {
   int i; // Counter
 
@@ -368,8 +368,8 @@ void AVL_postfixedR(AVLNode* tree, int aux)
   {
     if(tree)
     {
-      AVL_postfixedR(tree->right, aux+1);
-      AVL_postfixedR(tree->left, aux+1);
+      AVL_post_orderR(tree->right, aux+1);
+      AVL_post_orderR(tree->left, aux+1);
 
       for(i = 0; i < aux; i++)  // Printing the "stairs".
         printf("=");
@@ -379,28 +379,28 @@ void AVL_postfixedR(AVLNode* tree, int aux)
   }
   else
   {
-    AVL_postfixedR(tree->right, aux);
-    AVL_postfixedR(tree->left, aux);
+    AVL_post_orderR(tree->right, aux);
+    AVL_post_orderR(tree->left, aux);
 
     puts(tree->info);
   }
 }
 
-int AVL_centerside(AVLNode* tree, char side)
+int AVL_in_order(AVLNode* tree, char side)
 {
   int answer = 1;
 
   if(side == 'L')
-    AVL_centerL(tree, 1);
+    AVL_in_orderL(tree, 1);
   else if(side == 'R')
-    AVL_centerR(tree, 1);
+    AVL_in_orderR(tree, 1);
   else
     answer--;   // Answer = 0;
 
   return answer;
 }
 
-void AVL_centerL(AVLNode* tree, int aux)
+void AVL_in_orderL(AVLNode* tree, int aux)
 {
   int i; // Counter
 
@@ -408,27 +408,27 @@ void AVL_centerL(AVLNode* tree, int aux)
   {
     if(tree)
     {
-      AVL_centerL(tree->left, aux+1);
+      AVL_in_orderL(tree->left, aux+1);
 
       for(i = 0; i < aux; i++)  // Printing the "stairs".
         printf("=");
 
       puts(tree->info);
 
-      AVL_centerL(tree->right, aux+1);
+      AVL_in_orderL(tree->right, aux+1);
     }
   }
   else
   {
-    AVL_centerL(tree->left, aux);
+    AVL_in_orderL(tree->left, aux);
 
     puts(tree->info);
 
-    AVL_centerL(tree->right, aux);
+    AVL_in_orderL(tree->right, aux);
   }
 }
 
-void AVL_centerR(AVLNode* tree, int aux)
+void AVL_in_orderR(AVLNode* tree, int aux)
 {
   int i; // Counter
 
@@ -436,23 +436,23 @@ void AVL_centerR(AVLNode* tree, int aux)
   {
     if(tree)
     {
-      AVL_centerR(tree->right, aux+1);
+      AVL_in_orderR(tree->right, aux+1);
 
       for(i = 0; i < aux; i++)  // Printing the "stairs".
         printf("=");
 
       puts(tree->info);
 
-      AVL_centerR(tree->left, aux+1);
+      AVL_in_orderR(tree->left, aux+1);
     }
   }
   else
   {
-    AVL_centerR(tree->right, aux);
+    AVL_in_orderR(tree->right, aux);
 
     puts(tree->info);
 
-    AVL_centerR(tree->left, aux);
+    AVL_in_orderR(tree->left, aux);
   }
 }
 

--- a/ADT_AVL/ADT_AVL.h
+++ b/ADT_AVL/ADT_AVL.h
@@ -15,35 +15,35 @@ int comp_search_AVL;
 /* Returns a NULL pointer */
 AVLNode* AVL_initialize(void);
 
-/// AVL_insertion: AVLNode* char* int* int -> AVLNode*
+/// AVL_insert: AVLNode* char* int* int -> AVLNode*
 /* Inserts a new node in the given AVL tree, returning the new AVL tree with it.
    This function uses 4 others functions to balance the new tree:
     - AVL_rotateLeft
     - AVL_rotateRight
     - AVL_double_rotateLeft
     - AVL_double_rotateRight */
-AVLNode* AVL_insertion(AVLNode* tree, char *info, int* flag, int value);
+AVLNode* AVL_insert(AVLNode* tree, char *info, int* flag, int value);
 
 /// AVL_rotateLeft: AVLNode* -> AVLNode*
-/* Rotate to left the tree, usually to balance it. */
+/* Rotate the tree to the left, usually to balance it. */
 AVLNode* AVL_rotateLeft(AVLNode* tree);
 
 /// AVL_rotateRight: AVLNode* -> AVLNode*
-/* Rotate to right the tree, usually to balance it. */
+/* Rotate the tree to the right, usually to balance it. */
 AVLNode* AVL_rotateRight(AVLNode* tree);
 
 /// AVL_double_rotateLeft: AVLNode* -> AVLNode*
-/* Double rotate to left, usually to balance it.
-   Basically, this functions does first a right rotate with the right child of the given tree and
-  , then, a left rotate. Therefore, this function uses two others functions:
+/* Double rotate the tree to the left, usually to balance it.
+   Basically, this functions does first a right rotate with the right child of the given tree and,
+   then, a left rotate. Therefore, this function uses two others functions:
     - AVL_rotateRight
     - AVL_rotateLeft  */
 AVLNode* AVL_double_rotateLeft(AVLNode* tree);
 
 /// AVL_double_rotateRight: AVLNode* -> AVLNode*
 /* Double rotate to right, usually to balance it.
-   Basically, this functions does first a left rotate with the right child of the given tree and
-  , then, a right rotate. Therefore, this function uses two others functions:
+   Basically, this functions does first a left rotate with the right child of the given tree and,
+   then, a right rotate. Therefore, this function uses two others functions:
     - AVL_rotateLeft
     - AVL_rotateRight */
 AVLNode* AVL_double_rotateRight(AVLNode* tree);
@@ -52,9 +52,9 @@ AVLNode* AVL_double_rotateRight(AVLNode* tree);
 /* Given an info and a tree, it returns another tree without the node which had this info. */
 AVLNode* AVL_remove(AVLNode* tree, char *info);
 
-/// AVL_consult: AVLNode* char* -> AVLNode*
+/// AVL_search: AVLNode* char* -> AVLNode*
 /* Given an info and a tree, it returns a pointer to a node which has this info. If there isn't a info with this info, returns NULL. */
-AVLNode* AVL_consult(AVLNode* tree, char *info);
+AVLNode* AVL_search(AVLNode* tree, char *info);
 
 /// AVL_maxNode: AVLNode* -> AVLNode*
 /* Given a tree, this function returns a node which has the maximum key value. */
@@ -66,93 +66,93 @@ int AVL_height(AVLNode* tree);
 
 /// AVL_print: AVLNode* char* -> int
 /* Given a tree and a string, if given string is:
-    - "PREFIXEDL": it prints according pre-fixed left algorythm.
-    - "POSTFIXEDL": it prints according post-fixed left algorythm.
-    - "CENTERL": it prints according center left algorythm.
-    - "PREFIXEDR": it prints according pre-fixed right algorythm.
-    - "POSTFIXEDR": it prints according post-fixed right algorythm.
-    - "CENTERR": it prints according center right algorythm.
+    - "PREORDERL": prints according to the left pre-order traversal algorythm.
+    - "POSTORDERL": prints according to the left post-order traversal algorythm.
+    - "INORDERL": prints according to the left center traversal algorythm.
+    - "PREORDERR": prints according to the right pre-order traversal algorythm.
+    - "POSTORDERR": prints according to the right post-order traversal algorythm.
+    - "CENTERR": prints according to the right center traversal algorythm.
   This function uses three others functions:
-    - AVL_prefixed
-    - AVL_postfixed
-    - AVL_centerside
+    - AVL_pre_order
+    - AVL_post_order
+    - AVL_in_order
   If the given string isn't valid, the function returns 0. Else, returns 1. */
 int AVL_print(AVLNode* tree, char* operation);
 
-/// AVL_prefixed: AVLNode* char -> int
-/* Given a tree and a char, it prints the tree according pre-fixed algorythm.
-   According the char:
+/// AVL_pre_order: AVLNode* char -> int
+/* Given a tree and a char, it prints the tree according to the pre-order traversal algorythm.
+   According to the char:
       - 'L': left algorythm and returns 1.
       - 'R': right algorythm and returns 1.
       - Any other char: returns 0.
    This function uses two others functions:
-      - AVL_prefixedL
-      - AVL_prefixedR*/
-int AVL_prefixed(AVLNode* tree, char side);
+      - AVL_pre_orderL
+      - AVL_pre_orderR*/
+int AVL_pre_order(AVLNode* tree, char side);
 
-/// AVL_prefixedL: AVLNode* int -> void
-/* Given a tree and an auxiliar parameter, it prints the tree according pre-fixed left algorythm.
+/// AVL_pre_orderL: AVLNode* int -> void
+/* Given a tree and an auxiliar parameter, it prints the tree according to the left pre-order traversal algorythm.
    Aux could be:
       - 0: will print number above number.
       - 1: will print the tree "like stairs". */
-void AVL_prefixedL(AVLNode* tree, int aux);
+void AVL_pre_orderL(AVLNode* tree, int aux);
 
-/// AVL_prefixedR: AVLNode* int -> void
-/* Given a tree and an auxiliar parameter, it prints the tree according pre-fixed right algorythm.
+/// AVL_pre_orderR: AVLNode* int -> void
+/* Given a tree and an auxiliar parameter, it prints the tree according to the right pre-order traversal algorythm.
    Aux could be:
       - 0: will print number above number.
       - 1: will print the tree "like stairs". */
-void AVL_prefixedR(AVLNode* tree, int aux);
+void AVL_pre_orderR(AVLNode* tree, int aux);
 
-/// AVL_postfixed: AVLNode* char -> int
-/* Given a tree and a char, it prints the tree according post-fixed algorythm.
-   According the char:
+/// AVL_post_order: AVLNode* char -> int
+/* Given a tree and a char, it prints the tree according to the post-order traversal algorythm.
+   According to the char:
       - 'L': left algorythm and returns 1.
       - 'R': right algorythm and returns 1.
       - Any other char: returns 0.
    This function uses two others functions:
-      - AVL_postfixedL
-      - AVL_postfixedR*/
-int AVL_postfixed(AVLNode* tree, char side);
+      - AVL_post_orderL
+      - AVL_post_orderR*/
+int AVL_post_order(AVLNode* tree, char side);
 
-/// AVL_postfixedL: AVLNode* int -> void
-/* Given a tree and an auxiliar parameter, it prints the tree according post-fixed left algorythm.
+/// AVL_post_orderL: AVLNode* int -> void
+/* Given a tree and an auxiliar parameter, it prints the tree according to the left post-order traversal algorythm.
    Aux could be:
       - 0: will print number above number.
       - 1: will print the tree "like stairs". */
-void AVL_postfixedL(AVLNode* tree, int aux);
+void AVL_post_orderL(AVLNode* tree, int aux);
 
-/// AVL_postfixedR: AVLNode* int -> void
-/* Given a tree and an auxiliar parameter, it prints the tree according post-fixed right algorythm.
+/// AVL_post_orderR: AVLNode* int -> void
+/* Given a tree and an auxiliar parameter, it prints the tree according to the right post-order traversal algorythm.
    Aux could be:
       - 0: will print number above number.
       - 1: will print the tree "like stairs". */
-void AVL_postfixedR(AVLNode* tree, int aux);
+void AVL_post_orderR(AVLNode* tree, int aux);
 
-/// AVL_centerside: AVLNode* char -> int
-/* Given a tree and a char, it prints the tree according center-side algorythm.
-   According the char:
+/// AVL_in_order: AVLNode* char -> int
+/* Given a tree and a char, it prints the tree according to the in-order traversal algorythm.
+   According to the char:
       - 'L': left algorythm and returns 1.
       - 'R': right algorythm and returns 1.
       - Any other char: returns 0.
    This function uses two others functions:
-      - AVL_centerL
-      - AVL_centerR*/
-int AVL_centerside(AVLNode* tree, char side);
+      - AVL_in_orderL
+      - AVL_in_orderR*/
+int AVL_in_order(AVLNode* tree, char side);
 
-/// AVL_centerL: AVLNode* int -> void
-/* Given a tree and an auxiliar parameter, it prints the tree according center-left algorythm.
+/// AVL_in_orderL: AVLNode* int -> void
+/* Given a tree and an auxiliar parameter, it prints the tree according to the left in-order traversal algorythm.
    Aux could be:
       - 0: will print number above number.
       - 1: will print the tree "like stairs". */
 void AVL_centerL(AVLNode* tree, int aux);
 
 /// AVL_centerR: AVLNode* int -> void
-/* Given a tree and an auxiliar parameter, it prints the tree according center-right algorythm.
+/* Given a tree and an auxiliar parameter, it prints the tree according to the right in-order traversal algorythm.
    Aux could be:
       - 0: will print number above number.
       - 1: will print the tree "like stairs". */
-void AVL_centerR(AVLNode* tree, int aux);
+void AVL_in_orderR(AVLNode* tree, int aux);
 
 /// AVL_destroy: AVLNode* -> AVLNode*
 /* Given a tree, this function destroys it releasing used memory. */

--- a/ADT_BST/ADT_BST.c
+++ b/ADT_BST/ADT_BST.c
@@ -12,16 +12,16 @@ BSTNode* BST_initialize(void)
   return NULL;
 }
 
-BSTNode* BST_insertion(BSTNode* tree, char *info, int value)
+BSTNode* BST_insert(BSTNode* tree, char *info, int value)
 {
   comp_insert_BST++;
   if(tree)
   {
     comp_insert_BST++;
     if(strcmp(info,tree->info) > 0)
-      tree->right = BST_insertion(tree->right, info, value);
+      tree->right = BST_insert(tree->right, info, value);
     else
-      tree->left = BST_insertion(tree->left, info, value);
+      tree->left = BST_insert(tree->left, info, value);
   }
   else
   {
@@ -78,7 +78,7 @@ BSTNode* BST_remove(BSTNode* tree, char* info)
   return answer;
 }
 
-BSTNode* BST_consult(BSTNode* tree, char* info)
+BSTNode* BST_search(BSTNode* tree, char* info)
 {
   BSTNode* answer = NULL;  // Initializing return.
 
@@ -91,10 +91,10 @@ BSTNode* BST_consult(BSTNode* tree, char* info)
     else
     {
       comp_search_BST++;
-      if(strcmp(info,tree->info) > 0)   // If info is greater than info's tree, the answer will be the result of right consult.
-        answer = BST_consult(tree->right, info);
-      else                    // Else, it must be the result of left consult.
-        answer = BST_consult(tree->left, info);
+      if(strcmp(info,tree->info) > 0)   // If info is greater than info's tree, the answer will be the result of right search.
+        answer = BST_search(tree->right, info);
+      else                    // Else, it must be the result of left search.
+        answer = BST_search(tree->left, info);
     }
   }
 
@@ -137,17 +137,17 @@ int BST_print(BSTNode* tree, char* operation)
 
   if(tree)
   {
-    if(strcmp(operation, "PREFIXED") == 1)
+    if(strcmp(operation, "PREORDER") == 1)
     {
-      answer = BST_prefixed(tree, operation[8]);
+      answer = BST_pre_order(tree, operation[8]);
     }
-    else if(strcmp(operation, "POSTFIXED") == 1)
+    else if(strcmp(operation, "POSTORDER") == 1)
     {
-      answer = BST_postfixed(tree, operation[9]);
+      answer = BST_post_order(tree, operation[9]);
     }
-    else if(strcmp(operation, "CENTER") == 1)
+    else if(strcmp(operation, "INORDER") == 1)
     {
-      answer = BST_centerside(tree, operation[6]);
+      answer = BST_in_order(tree, operation[6]);
     }
     else
       answer--;
@@ -158,21 +158,21 @@ int BST_print(BSTNode* tree, char* operation)
   return answer;
 }
 
-int BST_prefixed(BSTNode* tree, char side)
+int BST_pre_order(BSTNode* tree, char side)
 {
   int answer = 1;
 
   if(side == 'L')
-    BST_prefixedL(tree, 1);
+    BST_pre_orderL(tree, 1);
   else if(side == 'R')
-    BST_prefixedR(tree, 1);
+    BST_pre_orderR(tree, 1);
   else
     answer--;   // Answer = 0;
 
   return answer;
 }
 
-void BST_prefixedL(BSTNode* tree, int aux)
+void BST_pre_orderL(BSTNode* tree, int aux)
 {
   int i; // Counter
 
@@ -185,20 +185,20 @@ void BST_prefixedL(BSTNode* tree, int aux)
 
       printf("%s\n", tree->info);
 
-      BST_prefixedL(tree->left, aux+1);
-      BST_prefixedL(tree->right, aux+1);
+      BST_pre_orderL(tree->left, aux+1);
+      BST_pre_orderL(tree->right, aux+1);
     }
   }
   else
   {
     printf("%s\n", tree->info);
 
-    BST_prefixedL(tree->left, aux);
-    BST_prefixedL(tree->right, aux);
+    BST_pre_orderL(tree->left, aux);
+    BST_pre_orderL(tree->right, aux);
   }
 }
 
-void BST_prefixedR(BSTNode* tree, int aux)
+void BST_pre_orderR(BSTNode* tree, int aux)
 {
   int i; // Counter
 
@@ -211,34 +211,34 @@ void BST_prefixedR(BSTNode* tree, int aux)
 
       printf("%s\n", tree->info);
 
-      BST_prefixedR(tree->right, aux+1);
-      BST_prefixedR(tree->left, aux+1);
+      BST_pre_orderR(tree->right, aux+1);
+      BST_pre_orderR(tree->left, aux+1);
     }
   }
   else
   {
     printf("%s\n", tree->info);
 
-    BST_prefixedR(tree->right, aux);
-    BST_prefixedR(tree->left, aux);
+    BST_pre_orderR(tree->right, aux);
+    BST_pre_orderR(tree->left, aux);
   }
 }
 
-int BST_postfixed(BSTNode* tree, char side)
+int BST_post_order(BSTNode* tree, char side)
 {
   int answer = 1;
 
   if(side == 'L')
-    BST_postfixedL(tree, 1);
+    BST_post_orderL(tree, 1);
   else if(side == 'R')
-    BST_postfixedR(tree, 1);
+    BST_post_orderR(tree, 1);
   else
     answer--;   // Answer = 0;
 
   return answer;
 }
 
-void BST_postfixedL(BSTNode* tree, int aux)
+void BST_post_orderL(BSTNode* tree, int aux)
 {
   int i; // Counter
 
@@ -246,8 +246,8 @@ void BST_postfixedL(BSTNode* tree, int aux)
   {
     if(tree)
     {
-      BST_postfixedL(tree->left, aux+1);
-      BST_postfixedL(tree->right, aux+1);
+      BST_post_orderL(tree->left, aux+1);
+      BST_post_orderL(tree->right, aux+1);
 
       for(i = 0; i < aux; i++)  // Printing the "stairs".
         printf("=");
@@ -257,14 +257,14 @@ void BST_postfixedL(BSTNode* tree, int aux)
   }
   else
   {
-    BST_postfixedL(tree->left, aux);
-    BST_postfixedL(tree->right, aux);
+    BST_post_orderL(tree->left, aux);
+    BST_post_orderL(tree->right, aux);
 
     printf("%s\n", tree->info);
   }
 }
 
-void BST_postfixedR(BSTNode* tree, int aux)
+void BST_post_orderR(BSTNode* tree, int aux)
 {
   int i; // Counter
 
@@ -272,8 +272,8 @@ void BST_postfixedR(BSTNode* tree, int aux)
   {
     if(tree)
     {
-      BST_postfixedR(tree->right, aux+1);
-      BST_postfixedR(tree->left, aux+1);
+      BST_post_orderR(tree->right, aux+1);
+      BST_post_orderR(tree->left, aux+1);
 
       for(i = 0; i < aux; i++)  // Printing the "stairs".
         printf("=");
@@ -283,28 +283,28 @@ void BST_postfixedR(BSTNode* tree, int aux)
   }
   else
   {
-    BST_postfixedR(tree->right, aux);
-    BST_postfixedR(tree->left, aux);
+    BST_post_orderR(tree->right, aux);
+    BST_post_orderR(tree->left, aux);
 
     printf("%s\n", tree->info);
   }
 }
 
-int BST_centerside(BSTNode* tree, char side)
+int BST_in_order(BSTNode* tree, char side)
 {
   int answer = 1;
 
   if(side == 'L')
-    BST_centerL(tree, 1);
+    BST_in_orderL(tree, 1);
   else if(side == 'R')
-    BST_centerR(tree, 1);
+    BST_in_orderR(tree, 1);
   else
     answer--;   // Answer = 0;
 
   return answer;
 }
 
-void BST_centerL(BSTNode* tree, int aux)
+void BST_in_orderL(BSTNode* tree, int aux)
 {
   int i; // Counter
 
@@ -312,27 +312,27 @@ void BST_centerL(BSTNode* tree, int aux)
   {
     if(tree)
     {
-      BST_centerL(tree->left, aux+1);
+      BST_in_orderL(tree->left, aux+1);
 
       for(i = 0; i < aux; i++)  // Printing the "stairs".
         printf("=");
 
       printf("%s\n", tree->info);
 
-      BST_centerL(tree->right, aux+1);
+      BST_in_orderL(tree->right, aux+1);
     }
   }
   else
   {
-    BST_centerL(tree->left, aux);
+    BST_in_orderL(tree->left, aux);
 
     printf("%s\n", tree->info);
 
-    BST_centerL(tree->right, aux);
+    BST_in_orderL(tree->right, aux);
   }
 }
 
-void BST_centerR(BSTNode* tree, int aux)
+void BST_in_orderR(BSTNode* tree, int aux)
 {
   int i; // Counter
 
@@ -340,23 +340,23 @@ void BST_centerR(BSTNode* tree, int aux)
   {
     if(tree)
     {
-      BST_centerR(tree->right, aux+1);
+      BST_in_orderR(tree->right, aux+1);
 
       for(i = 0; i < aux; i++)  // Printing the "stairs".
         printf("=");
 
       printf("%s\n", tree->info);
 
-      BST_centerR(tree->left, aux+1);
+      BST_in_orderR(tree->left, aux+1);
     }
   }
   else
   {
-    BST_centerR(tree->right, aux);
+    BST_in_orderR(tree->right, aux);
 
     printf("%s\n", tree->info);
 
-    BST_centerR(tree->left, aux);
+    BST_in_orderR(tree->left, aux);
   }
 }
 

--- a/ADT_BST/ADT_BST.h
+++ b/ADT_BST/ADT_BST.h
@@ -14,17 +14,17 @@ int comp_search_BST;
 /* Returns a NULL pointer */
 BSTNode* BST_initialize(void);
 
-/// BST_insertion: BSTNode* char* int -> BSTNode*
+/// BST_insert: BSTNode* char* int -> BSTNode*
 /* Inserts a new node in the tree, returning the new tree with it. */
-BSTNode* BST_insertion(BSTNode* tree, char* info, int value);
+BSTNode* BST_insert(BSTNode* tree, char* info, int value);
 
 /// BST_remove: BSTNode* char* -> BSTNode*
 /* Given an info and a tree, it returns another tree without the node which had this info. */
 BSTNode* BST_remove(BSTNode* tree, char* info);
 
-/// BST_consult: BSTNode* char* -> BSTNode*
-/* Given an info and a tree, it returns a pointer to a node which has this info. If there isn't a info with this info, returns NULL. */
-BSTNode* BST_consult(BSTNode* tree, char* info);
+/// BST_search: BSTNode* char* -> BSTNode*
+/* Given an info and a tree, it returns a pointer to a node which has this info. If there isn't a node with this info, returns NULL. */
+BSTNode* BST_search(BSTNode* tree, char* info);
 
 /// BST_maxNode: BSTNode* -> BSTNode*
 /* Given a tree, this function returns a node which has the maximum key value. */
@@ -36,93 +36,93 @@ int BST_height(BSTNode* tree);
 
 /// BST_print: BSTNode* char* -> int
 /* Given a tree and a string, if given string is:
-    - "PREFIXEDL": it prints according pre-fixed left algorythm.
-    - "POSTFIXEDL": it prints according post-fixed left algorythm.
-    - "CENTERL": it prints according center left algorythm.
-    - "PREFIXEDR": it prints according pre-fixed right algorythm.
-    - "POSTFIXEDR": it prints according post-fixed right algorythm.
-    - "CENTERR": it prints according center right algorythm.
+    - "PREORDERL": prints according to the left pre-order traversal algorythm.
+    - "POSTORDERL": prints according to the left post-order traversal algorythm.
+    - "INORDERL": prints according to the left in-order traversal algorythm.
+    - "PREORDERR": prints according to the right pre-order traversal algorythm.
+    - "POSTORDERR": prints according to the right post-order traversal algorythm.
+    - "INORDERR": prints according to the right in-order traversal algorythm.
   This function uses three others functions:
-    - BST_prefixed
-    - BST_postfixed
-    - BST_centerside
+    - BST_pre_order
+    - BST_post_order
+    - BST_in_order
   If the given string isn't valid, the function returns 0. Else, returns 1. */
 int BST_print(BSTNode* tree, char* operation);
 
-/// BST_prefixed: BSTNode* char -> int
-/* Given a tree and a char, it prints the tree according pre-fixed algorythm.
+/// BST_pre_order: BSTNode* char -> int
+/* Given a tree and a char, it prints the tree according to the pre-order traversal algorythm.
    According the char:
       - 'L': left algorythm and returns 1.
       - 'R': right algorythm and returns 1.
       - Any other char: returns 0.
    This function uses two others functions:
-      - BST_prefixedL
-      - BST_prefixedR*/
-int BST_prefixed(BSTNode* tree, char side);
+      - BST_pre_orderL
+      - BST_pre_orderR*/
+int BST_pre_order(BSTNode* tree, char side);
 
-/// BST_prefixedL: BSTNode* int -> void
-/* Given a tree and an auxiliar parameter, it prints the tree according pre-fixed left algorythm.
+/// BST_pre_orderL: BSTNode* int -> void
+/* Given a tree and an auxiliar parameter, it prints the tree according to the left pre-order traversal algorythm.
    Aux could be:
       - 0: will print number above number.
       - 1: will print the tree "like stairs". */
-void BST_prefixedL(BSTNode* tree, int aux);
+void BST_pre_orderL(BSTNode* tree, int aux);
 
-/// BST_prefixedR: BSTNode* int -> void
-/* Given a tree and an auxiliar parameter, it prints the tree according pre-fixed right algorythm.
+/// BST_pre_orderR: BSTNode* int -> void
+/* Given a tree and an auxiliar parameter, it prints the tree according to the right pre-order traversal algorythm.
    Aux could be:
       - 0: will print number above number.
       - 1: will print the tree "like stairs". */
-void BST_prefixedR(BSTNode* tree, int aux);
+void BST_pre_orderR(BSTNode* tree, int aux);
 
-/// BST_postfixed: BSTNode* char -> int
-/* Given a tree and a char, it prints the tree according post-fixed algorythm.
+/// BST_post_order: BSTNode* char -> int
+/* Given a tree and a char, it prints the tree according to the post-order algorythm.
+   According to the char:
+      - 'L': left algorythm and returns 1.
+      - 'R': right algorythm and returns 1.
+      - Any other char: returns 0.
+   This function uses two others functions:
+      - BST_post_orderL
+      - BST_post_orderR*/
+int BST_post_order(BSTNode* tree, char side);
+
+/// BST_post_orderL: BSTNode* int -> void
+/* Given a tree and an auxiliar parameter, it prints the tree according to the post-order left algorythm.
+   Aux could be:
+      - 0: will print number above number.
+      - 1: will print the tree "like stairs". */
+void BST_post_orderL(BSTNode* tree, int aux);
+
+/// BST_post_orderR: BSTNode* int -> void
+/* Given a tree and an auxiliar parameter, it prints the tree according to the post-order right algorythm.
+   Aux could be:
+      - 0: will print number above number.
+      - 1: will print the tree "like stairs". */
+void BST_post_orderR(BSTNode* tree, int aux);
+
+/// BST_in_order: BSTNode* char -> int
+/* Given a tree and a char, it prints the tree according to the in-order traversal algorythm.
    According the char:
       - 'L': left algorythm and returns 1.
       - 'R': right algorythm and returns 1.
       - Any other char: returns 0.
    This function uses two others functions:
-      - BST_postfixedL
-      - BST_postfixedR*/
-int BST_postfixed(BSTNode* tree, char side);
+      - BST_in_orderL
+      - BST_in_orderR */
+int BST_in_order(BSTNode* tree, char side);
 
-/// BST_postfixedL: BSTNode* int -> void
-/* Given a tree and an auxiliar parameter, it prints the tree according post-fixed left algorythm.
+/// BST_in_orderL: BSTNode* int -> void
+/* Given a tree and an auxiliar parameter, it prints the tree according to the left in-order traversal algorythm.
    Aux could be:
       - 0: will print number above number.
       - 1: will print the tree "like stairs". */
-void BST_postfixedL(BSTNode* tree, int aux);
+void BST_in_orderL(BSTNode* tree, int aux);
 
-/// BST_postfixedR: BSTNode* int -> void
-/* Given a tree and an auxiliar parameter, it prints the tree according post-fixed right algorythm.
+/// BST_in_orderR: BSTNode* int -> void
+/* Given a tree and an auxiliar parameter, it prints the tree according to the right in-order traversal algorythm.
    Aux could be:
       - 0: will print number above number.
       - 1: will print the tree "like stairs". */
-void BST_postfixedR(BSTNode* tree, int aux);
-
-/// BST_centerside: BSTNode* char -> int
-/* Given a tree and a char, it prints the tree according center-side algorythm.
-   According the char:
-      - 'L': left algorythm and returns 1.
-      - 'R': right algorythm and returns 1.
-      - Any other char: returns 0.
-   This function uses two others functions:
-      - BST_centerL
-      - BST_centerR*/
-int BST_centerside(BSTNode* tree, char side);
-
-/// BST_centerL: BSTNode* int -> void
-/* Given a tree and an auxiliar parameter, it prints the tree according center-left algorythm.
-   Aux could be:
-      - 0: will print number above number.
-      - 1: will print the tree "like stairs". */
-void BST_centerL(BSTNode* tree, int aux);
-
-/// BST_centerR: BSTNode* int -> void
-/* Given a tree and an auxiliar parameter, it prints the tree according center-right algorythm.
-   Aux could be:
-      - 0: will print number above number.
-      - 1: will print the tree "like stairs". */
-void BST_centerR(BSTNode* tree, int aux);
+void BST_in_orderR(BSTNode* tree, int aux);
 
 /// BST_destroy: BSTNode* -> BSTNode*
 /* Given a tree, this function destroys it releasing used memory. */

--- a/Application.layout
+++ b/Application.layout
@@ -2,14 +2,14 @@
 <CodeBlocks_layout_file>
 	<FileVersion major="1" minor="0" />
 	<ActiveTarget name="Debug" />
-	<File name="ADT_AVL\ADT_AVL.c" open="1" top="0" tabpos="2" split="0" active="1" splitpos="0" zoom_1="0" zoom_2="0">
+	<File name="ADT_AVL\ADT_AVL.c" open="0" top="0" tabpos="2" split="0" active="1" splitpos="0" zoom_1="0" zoom_2="0">
 		<Cursor>
-			<Cursor1 position="283" topLine="0" />
+			<Cursor1 position="0" topLine="0" />
 		</Cursor>
 	</File>
 	<File name="main.c" open="1" top="1" tabpos="1" split="0" active="1" splitpos="0" zoom_1="0" zoom_2="0">
 		<Cursor>
-			<Cursor1 position="1274" topLine="43" />
+			<Cursor1 position="187" topLine="0" />
 		</Cursor>
 	</File>
 </CodeBlocks_layout_file>

--- a/main.c
+++ b/main.c
@@ -59,14 +59,14 @@ int main(int argc, char *argv[])
 
       if(auxiliarString != NULL)
       {
-        strcpy(bufferString, auxiliarString); // Saving word to use in insertion.
+        strcpy(bufferString, auxiliarString); // Saving word to use in insert.
 
         pointerString = strtok(NULL, separateChars); // Word's value string.
 
         auxiliarValue = atoi(pointerString); // Converting string to value.
 
-        bst_Tree = BST_insertion(bst_Tree, bufferString, auxiliarValue);  // Inserting in BST.
-        avl_Tree = AVL_insertion(avl_Tree, bufferString, factorFlag, auxiliarValue);  // Inserting in AVL.
+        bst_Tree = BST_insert(bst_Tree, bufferString, auxiliarValue);  // Inserting in BST.
+        avl_Tree = AVL_insert(avl_Tree, bufferString, factorFlag, auxiliarValue);  // Inserting in AVL.
 
         word_count++; // Incrementing word count for future analysis
       }


### PR DESCRIPTION
- Changed the naming of the printing functions, to be according to the usual english naming:
    - insertion -> insert
    - consult -> search
    - prefixed -> pre_order
    - centerside -> in_order
    - postfixed -> post_order
- Also fixed some typos in the header files